### PR TITLE
Blink red button once as NACK

### DIFF
--- a/software/two_button.py
+++ b/software/two_button.py
@@ -74,6 +74,7 @@ class Dispatcher(BaseDispatcher):
       self.expecting_press_timer.set(30)
       self.on_button.blink()
     else:
+      self.off_button.blink(1)
       self.buzzer.beep()
       if self.noise:
         self.noise.kill()
@@ -84,6 +85,7 @@ class Dispatcher(BaseDispatcher):
   def on_button_down(self, source):
     print "Button down", source
     if not self.authorized:
+      self.off_button.blink(1)
       self.buzzer.beep()
       if self.noise:
         self.noise.kill()


### PR DESCRIPTION
The logic behind the finite blink count also allows for a theoretical future case where maybe you wish to keep the red light normally on as a power indicator (e.g. in case the badge reader didn't have its own power light). In that case, a blink would turn it off temporarily then return it back to it's normal "on" state. The current "finite blink" code works correctly with either a normally on or normally off light.