### PR TITLE
doc/bug: Fixing 404 errors in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ employees all have the same kind of RFID badge:
 
 ## Organization
 
+    docs/
+      Documentation on the project to include contributions on tool connectivity.
     software/
       The Python client that runs on a Pi.
     hardware/
       The custom Pi hat we use to interact with buttons and a power switch tail.
-    sample_server/
-      A simple Django server that lets you view tool logs and authorize people.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,8 @@ the community and welcoming contributions that help it work with more tools.
 
 ### Assembling your Authboard 1.0
 
-* [authboard-1.0/BOM](authboard-1.0/BOM)
-* [authboard-1.0/Soldering](authboard-1.0/Soldering)
+* [authboard-v1.0/BOM.md](authboard-v1.0/BOM.md)
+* [authboard-v1.0/Soldering.md](authboard-v1.0/Soldering.md)
 
 ![Authboard](authboard_v10.jpg)
 
@@ -18,9 +18,9 @@ the community and welcoming contributions that help it work with more tools.
 
 ### Connecting to servers
 
-* [server/Protocol](server/Protocol)
+* [server/Protocol.md](server/Protocol.md)
 
 ### Client software
 
-* [client/Walkthrough](client/Walkthrough)
+* [client/Walkthrough.md](client/Walkthrough.md)
 


### PR DESCRIPTION
Recent changes to the docs were using incorrect filenames in the
documentation (missing the `.md` file extention which is required for
files beyond `README.md` as the default in a directory).

doc: Updating main README.md, removing stale data

Previously the main README.md in the project referenced a sample python
server which is no longer a part of the project.  Additionally, there is
now a more clearly codified location for documentation in the project.