### PR TITLE
Avoid commit issues with sample credential files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 *.bak
 cover
 .coverage
+
+# ignore files called out in sample_auth_check.sh to avoid issues
+authorized.txt
+log.txt


### PR DESCRIPTION
The file `sample_auth_check.sh` refers to two files which should not be
kept in revision control:
  - `authorized.txt`
  - `logs.txt`

This addition to `.gitignore` keeps those files from accidentally being
commited.