### PR TITLE
device: Wiegand badge reader support

### DIFF
--- a/software/authbox/api.py
+++ b/software/authbox/api.py
@@ -37,6 +37,7 @@ from authbox.compat import queue
 
 CLASS_REGISTRY = [
     'authbox.badgereader_hid_keystroking.HIDKeystrokingReader',
+    'authbox.badgereader_wiegand_gpio.WiegandGPIOReader',
     'authbox.gpio_button.Button',
     'authbox.gpio_relay.Relay',
     'authbox.gpio_buzzer.Buzzer',
@@ -138,6 +139,21 @@ class BasePinThread(BaseDerivedThread):
       GPIO.setup(self.input_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
     if self.output_pin:
       GPIO.setup(self.output_pin, GPIO.OUT, initial=initial_output)
+
+
+class BaseWiegandPinThread(BaseDerivedThread):
+  def __init__(self, event_queue, config_name, d0_pin, d1_pin):
+    super(BaseWiegandPinThread, self).__init__(event_queue, config_name)
+
+    self.d0_pin = d0_pin
+    self.d1_pin = d1_pin
+
+    GPIO.setmode(GPIO.BOARD)
+    GPIO.setwarnings(False)  # for reusing pins
+    if self.d0_pin:
+      GPIO.setup(self.d0_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+    if self.d1_pin:
+      GPIO.setup(self.d1_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
 
 class NoMatchingDevice(Exception):

--- a/software/authbox/badgereader_wiegand_gpio.py
+++ b/software/authbox/badgereader_wiegand_gpio.py
@@ -1,0 +1,111 @@
+# Copyright 2018 Ace Monster Toys. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wiegand based badge reader directly connected via GPIO
+"""
+
+from __future__ import print_function, division
+
+import time
+
+from authbox.api import BaseWiegandPinThread, GPIO
+from authbox.compat import queue
+
+
+DEFAULT_QUEUE_SIZE = 100  # more than enough for a scan
+DEFAULT_TIMEOUT_IN_MS = 15
+
+
+class WiegandGPIOReader(BaseWiegandPinThread):
+  """Badge reader hardware abstraction.
+
+  A Wiegand GPIO badge reader is defined in config as:
+
+    [pins]
+    name = WiegandGPIOReader:7:13
+
+  where 7 is the D0 pin (physical numbering), and 13 is the D1 pin (also 
+  physical numbering).  In this configuration the 6 pin J5 connector will be
+  structured as follows:
+      Pin 1: D0
+      Pin 2: D1
+      Pin 3: No connection
+      Pin 4: Ground
+      Pin 5: 12v
+      Pin 6: No connection
+
+  Pin 6 is used for the switched +12v provided by the ULN2003AD chip
+  (L5_LOGIC).  As we want to constantly power the RFID reader, there is no need
+  to populate Pin 6.
+
+  It should also be noted that most GPIO based RFID badge readers operate at 5v
+  logic, so one should use care when connecting them to the host.  Most readers
+  communicate only from the reader to the host.  If this is the case a simple
+  voltage divider is sufficient to protect the GPIO pins on the host, in the
+  event that two way communication is needed a level shifter should be used.
+  """
+
+  def __init__(self, event_queue, config_name, d0_pin, d1_pin, on_scan=None,
+               queue_size=DEFAULT_QUEUE_SIZE,
+               timeout_in_ms=DEFAULT_TIMEOUT_IN_MS):
+    super(WiegandGPIOReader, self).__init__(
+        event_queue, config_name, int(d0_pin), int(d1_pin))
+    self._on_scan = on_scan
+    # The limited-size queue protects from a slow leak in case of deadlock, so
+    # we can detect and output something (just a print for now)
+    self.bitqueue = queue.Queue(int(queue_size))
+    self.timeout_in_seconds = float(timeout_in_ms) / 1000
+
+    if self._on_scan:
+        GPIO.add_event_detect(self.d0_pin, GPIO.FALLING, callback=self.decode)
+        GPIO.add_event_detect(self.d1_pin, GPIO.FALLING, callback=self.decode)
+
+  def decode(self, channel):
+    bit = "0" if channel == self.d0_pin else "1"
+    try:
+      self.bitqueue.put_nowait(bit)
+    except queue.Full:
+      # This shouldn't happen.
+      print("{name} BUG: QUEUE FULL".format(name=self.__class__.__name__))
+
+  def read_input(self):
+    """
+    This thread will perform a blocking read.  If there are no bits coming in
+    the stream, this will actually wait for them to start coming in.
+
+    Args:
+      None
+
+    Returns:
+      badge value as string of 0's and 1's.
+    """
+    # Wait for a first bit to come in, slightly better than a busy-wait
+    while self.bitqueue.empty():
+        time.sleep(0.001)
+
+    ## this will currently have a race condition where two cards read back
+    ## to back as one giant card
+    bits = []
+    while True:
+        try:
+            bit = self.bitqueue.get(timeout=self.timeout_in_seconds)
+        except queue.Empty:
+            break
+        bits.append(bit)
+
+    return ''.join(bits)
+
+  def run_inner(self):
+    line = self.read_input()
+    self.event_queue.put((self._on_scan, line))

--- a/software/authbox/fake_gpio_for_testing.py
+++ b/software/authbox/fake_gpio_for_testing.py
@@ -51,7 +51,7 @@ class FakeGPIO(object):
   def press(self, n, edge):
     # TODO support bidirectional edge
     if self.events[n] and self.events[n][0] == edge:
-      self.events[n][1]()
+      self.events[n][1](n)
 
   def compare_log(self, expected_log):
     """Check that the correct log entries exist in the right order.

--- a/software/authbox/test_badgereader_wiegand_gpio.py
+++ b/software/authbox/test_badgereader_wiegand_gpio.py
@@ -1,0 +1,66 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for authbox.badgereader_wiegand_gpio"""
+
+import threading
+import time
+import unittest
+
+import authbox.badgereader_wiegand_gpio
+from authbox import fake_gpio_for_testing
+from authbox.compat import queue
+from RPi import GPIO
+
+
+class BadgereaderWiegandGPIOTest(unittest.TestCase):
+  def setup(self):
+    self.fake = fake_gpio_for_testing.FakeGPIO()
+    self.q = Queue.Queue()
+    self.b = authbox.badgereader_wiegand_gpio.WiegandGPIOReader(
+        self.q,
+        'b',
+        '7',
+        '13',
+        on_scan=self.on_scan,
+    )
+
+  def on_scan(self, badge_number):
+    pass
+
+  def test_simple_scan(self):
+    self.fake.press(1, GPIO.FALLING)
+    self.fake.press(0, GPIO.FALLING)
+    self.b.run_inner()
+    self.assertEqual(self.q.get(block=False), (self.on_scan, "10"))
+
+  def test_blocks_until_scan(self):
+
+    def add_bits_later():
+      time.sleep(0.2)
+      self.fake.press(1, GPIO.FALLING)
+      self.fake.press(0, GPIO.FALLING)
+
+    t = threading.Thread(target=add_bits_later)
+    t.start()
+    self.b.run_inner()
+    self.assertEqual(self.q.get(block=False), (self.on_scan, "10"))
+
+  def test_limited_queue_size(self):
+    for i in range(500):
+      self.fake.press(0, GPIO.FALLING)
+    self.b.run_inner()
+    self.assertEqual(self.q.get(block=False), (self.on_scan, "0" * 100))
+    # Make sure that state is reset.
+    self.assertTrue(self.b.bitqueue.empty())


### PR DESCRIPTION
This commit provides support for [Wiegand][1] style badge readers.  It has
been tested with a number of EM4100 style readers and has been used in
production for a number of months without issue.

The wiring for a badge reader requires two data GPIO pins as input.
These pins within the Wiegand protocol are "D0" and "D1" respectively.
Normally, these pins are pulled high (generally to 5v).  They perform
differential signalling through pulling D0 low to represent a "0" and
pulling D1 low to represent a "1".

This introduces some challenges as most of the connectors have only a
single raw GPIO input.  In practice, this has been used with J5
consuming the B5_LOGIC and B6_LOGIC pins (pin 13 and 7 respectively on
version 1.0 of the Makerspace Auth board).

Within the code this bitstream of "1"s and "0"s is represented as a
string so as to avoid additional dependencies as well as to not worry
about specific card formats.

Ultimately this module should pedantically output the hexadecimal value
and leave card ids, facility codes, and other format specific nuances to
other components of software.  At the present time, this module merely
returns the internal string and leaves the parsing to the user.

[1]: https://en.wikipedia.org/wiki/Wiegand_interface

Add tests and switch to queue for badgereader_wiegand.

The queue actually makes the testing logic way easier.

This contains a patch originally by Tim Hatch:
https://github.com/thatch/makerspace-auth/commit/f100d31e227aa26cbabc8dfa77ad170669ea8010