### PR TITLE
Fix docstring indentation after Python Black reformat

### DIFF
--- a/software/authbox/badgereader_hid_keystroking.py
+++ b/software/authbox/badgereader_hid_keystroking.py
@@ -25,21 +25,21 @@ from authbox.api import BaseDerivedThread, NoMatchingDevice
 class HIDKeystrokingReader(BaseDerivedThread):
     """Badge reader hardware abstraction.
 
-  A badge reader is defined in config as:
+    A badge reader is defined in config as:
 
-    [pins]
-    name = HIDKeystrokingReader:<Name>
+      [pins]
+      name = HIDKeystrokingReader:<Name>
 
-  Where `<Name>` is the name evdev sees.  This appears to match a substring of
-  /dev/input/by-id, for example if that directory contains
-  `usb-RFIDeas_USB_Keyboard-event-kbd`, the evdev name is `RFIdeas USB
-  Keyboard` with spaces.  You can confirm this in Python by executing:
+    Where `<Name>` is the name evdev sees.  This appears to match a substring of
+    /dev/input/by-id, for example if that directory contains
+    `usb-RFIDeas_USB_Keyboard-event-kbd`, the evdev name is `RFIdeas USB
+    Keyboard` with spaces.  You can confirm this in Python by executing:
 
-  >>> import evdev
-  >>> [evdev.InputDevice(d).name() for d in evdev.list_devices()]
+    >>> import evdev
+    >>> [evdev.InputDevice(d).name() for d in evdev.list_devices()]
 
-  This has been tested on a couple of brands of reader and seems to be pretty generic.
-  """
+    This has been tested on a couple of brands of reader and seems to be pretty generic.
+    """
 
     scancodes = {
         # Scancode: ASCIICode
@@ -180,9 +180,9 @@ class HIDKeystrokingReader(BaseDerivedThread):
     def get_scanner_device(self):
         """Finds connected device matching device_name.
 
-    Returns:
-      The file for input events that read_input can listen to
-    """
+        Returns:
+          The file for input events that read_input can listen to
+        """
 
         devices = [evdev.InputDevice(x) for x in evdev.list_devices()]
         for dev in devices:
@@ -196,12 +196,12 @@ class HIDKeystrokingReader(BaseDerivedThread):
     def read_input(self):
         """Listens solely to the RFID keyboard and returns the scanned badge.
 
-    Args:
-      device: input device to listen to
+        Args:
+          device: input device to listen to
 
-    Returns:
-      badge value as string
-    """
+        Returns:
+          badge value as string
+        """
 
         rfid = ""
         capitalized = 0

--- a/software/authbox/badgereader_wiegand_gpio.py
+++ b/software/authbox/badgereader_wiegand_gpio.py
@@ -27,31 +27,31 @@ DEFAULT_TIMEOUT_IN_MS = 15
 class WiegandGPIOReader(BaseWiegandPinThread):
     """Badge reader hardware abstraction.
 
-  A Wiegand GPIO badge reader is defined in config as:
+    A Wiegand GPIO badge reader is defined in config as:
 
-    [pins]
-    name = WiegandGPIOReader:7:13
+      [pins]
+      name = WiegandGPIOReader:7:13
 
-  where 7 is the D0 pin (physical numbering), and 13 is the D1 pin (also
-  physical numbering).  In this configuration the 6 pin J5 connector will be
-  structured as follows:
-      Pin 1: D0
-      Pin 2: D1
-      Pin 3: No connection
-      Pin 4: Ground
-      Pin 5: 12v
-      Pin 6: No connection
+    where 7 is the D0 pin (physical numbering), and 13 is the D1 pin (also
+    physical numbering).  In this configuration the 6 pin J5 connector will be
+    structured as follows:
+        Pin 1: D0
+        Pin 2: D1
+        Pin 3: No connection
+        Pin 4: Ground
+        Pin 5: 12v
+        Pin 6: No connection
 
-  Pin 6 is used for the switched +12v provided by the ULN2003AD chip
-  (L5_LOGIC).  As we want to constantly power the RFID reader, there is no need
-  to populate Pin 6.
+    Pin 6 is used for the switched +12v provided by the ULN2003AD chip
+    (L5_LOGIC).  As we want to constantly power the RFID reader, there is no need
+    to populate Pin 6.
 
-  It should also be noted that most GPIO based RFID badge readers operate at 5v
-  logic, so one should use care when connecting them to the host.  Most readers
-  communicate only from the reader to the host.  If this is the case a simple
-  voltage divider is sufficient to protect the GPIO pins on the host, in the
-  event that two way communication is needed a level shifter should be used.
-  """
+    It should also be noted that most GPIO based RFID badge readers operate at 5v
+    logic, so one should use care when connecting them to the host.  Most readers
+    communicate only from the reader to the host.  If this is the case a simple
+    voltage divider is sufficient to protect the GPIO pins on the host, in the
+    event that two way communication is needed a level shifter should be used.
+    """
 
     def __init__(
         self,
@@ -86,15 +86,15 @@ class WiegandGPIOReader(BaseWiegandPinThread):
 
     def read_input(self):
         """
-    This thread will perform a blocking read.  If there are no bits coming in
-    the stream, this will actually wait for them to start coming in.
+        This thread will perform a blocking read.  If there are no bits coming in
+        the stream, this will actually wait for them to start coming in.
 
-    Args:
-      None
+        Args:
+          None
 
-    Returns:
-      badge value as string of 0's and 1's.
-    """
+        Returns:
+          badge value as string of 0's and 1's.
+        """
         # Wait for a first bit to come in
         bit = self.bitqueue.get(block=True)
 

--- a/software/authbox/config.py
+++ b/software/authbox/config.py
@@ -28,20 +28,20 @@ TIME_RE = re.compile(r"([\d.]+)([smhd])")
 def recursive_config_lookup(value, config, section, stack=None):
     """Looks up format references in ConfigParser objects.
 
-  For the sample config:
+    For the sample config:
 
-      [s]
-      k = v
+        [s]
+        k = v
 
-  Args:
-    value: The format string, e.g. passing '{k}' (and 's' for section) will return 'v'
-    config: A ConfigParser object.
-    section: The section in which values will be looked up.
-    stack: Omit for client call; will be provided when recursing to check for
-      infinite loops.
-  Returns:
-    A string with references replaced.
-  """
+    Args:
+      value: The format string, e.g. passing '{k}' (and 's' for section) will return 'v'
+      config: A ConfigParser object.
+      section: The section in which values will be looked up.
+      stack: Omit for client call; will be provided when recursing to check for
+        infinite loops.
+    Returns:
+      A string with references replaced.
+    """
     if stack is None:
         stack = []
     # Typically these are shallow, so this is efficient enough
@@ -86,17 +86,17 @@ class Config(object):
     def parse_time(cls, time_string):
         """Parse a time string.
 
-    Allowable suffixes include:
+        Allowable suffixes include:
 
-      s: seconds
-      m: minutes
-      h: hours
-      d: days
+          s: seconds
+          m: minutes
+          h: hours
+          d: days
 
-    and can be mixed, e.g. 1m30s.
+        and can be mixed, e.g. 1m30s.
 
-    Returns the value in seconds, as an int if possible, otherwise a float.
-    """
+        Returns the value in seconds, as an int if possible, otherwise a float.
+        """
         units = {
             "s": 1,
             "m": 60,

--- a/software/authbox/fake_gpio_for_testing.py
+++ b/software/authbox/fake_gpio_for_testing.py
@@ -59,9 +59,9 @@ class FakeGPIO(object):
     def compare_log(self, expected_log):
         """Check that the correct log entries exist in the right order.
 
-    Raises:
-      Exception: if that is not true.
-    """
+        Raises:
+          Exception: if that is not true.
+        """
         # Entries must appear in the correct order, and only count for one.
         print("Expecting", expected_log)
         print("Actual", self.log)

--- a/software/authbox/gpio_button.py
+++ b/software/authbox/gpio_button.py
@@ -22,15 +22,15 @@ from authbox.compat import queue
 class Button(BasePinThread):
     """Button hardware abstraction.
 
-  A button is defined in config as:
+    A button is defined in config as:
 
-    [pins]
-    name = Button:1:2
+      [pins]
+      name = Button:1:2
 
-  where 1 is the active-low input pin (physical numbering), and 2 is the output
-  pin (also physical numbering).  If you have another kind of button, you
-  probably need a different class.
-  """
+    where 1 is the active-low input pin (physical numbering), and 2 is the output
+    pin (also physical numbering).  If you have another kind of button, you
+    probably need a different class.
+    """
 
     def __init__(
         self,
@@ -78,17 +78,17 @@ class Button(BasePinThread):
     def blink(self):
         """Blink the light indefinitely.
 
-    The time for each on or off pulse is `blink_duration`."""
+        The time for each on or off pulse is `blink_duration`."""
         self.blink_command_queue.put((True,))
 
     def on(self):
         """Turn the light (if present) on indefinitely.
 
-    If the light is currently in the blink state, it stops blinking."""
+        If the light is currently in the blink state, it stops blinking."""
         self.blink_command_queue.put((False, True))
 
     def off(self):
         """Turn the light (if present) off indefinitely.
 
-    If the light is currently in the blink state, it stops blinkin."""
+        If the light is currently in the blink state, it stops blinkin."""
         self.blink_command_queue.put((False, False))

--- a/software/authbox/gpio_buzzer.py
+++ b/software/authbox/gpio_buzzer.py
@@ -32,16 +32,16 @@ BEEP = 5
 class Buzzer(BasePinThread):
     """Buzzer hardware abstraction.
 
-  A buzzer is defined in config as:
+    A buzzer is defined in config as:
 
-    [pins]
-    name = Buzzer:1
+      [pins]
+      name = Buzzer:1
 
-  where 1 is the active-high output pin.  This only works with buzzers that
-  sound when driven with DC.  If you need to output a square wave, investigate
-  gpio_tonal_buzzer.py in the source history, and making that work with pigpio
-  for more stable frequency.
-  """
+    where 1 is the active-high output pin.  This only works with buzzers that
+    sound when driven with DC.  If you need to output a square wave, investigate
+    gpio_tonal_buzzer.py in the source history, and making that work with pigpio
+    for more stable frequency.
+    """
 
     def __init__(self, event_queue, config_name, output_pin):
         super(Buzzer, self).__init__(event_queue, config_name, None, int(output_pin))

--- a/software/authbox/gpio_relay.py
+++ b/software/authbox/gpio_relay.py
@@ -27,14 +27,14 @@ types = {
 class Relay(BasePinThread):
     """Relay hardware abstraction.
 
-  A relay is defined in config as:
+    A relay is defined in config as:
 
-    [pins]
-    name = Relay:ActiveHigh:1
+      [pins]
+      name = Relay:ActiveHigh:1
 
-  where ActiveHigh may instead be ActiveLow, as appropriate, and 1 is the output
-  pin (physical numbering).
-  """
+    where ActiveHigh may instead be ActiveLow, as appropriate, and 1 is the output
+    pin (physical numbering).
+    """
 
     def __init__(self, event_queue, config_name, output_type, output_pin):
         super(Relay, self).__init__(


### PR DESCRIPTION
Black changed the indent from 2 to 4 spaces but it doesn't seem
to handle docstring indentation at all.