### PR TITLE
Improve GPIO reliability by adding de-bouncing code and ensure feedback on keypress

### DIFF
--- a/software/authbox/gpio_button.py
+++ b/software/authbox/gpio_button.py
@@ -64,14 +64,14 @@ class Button(BasePinThread):
         # Looks for 5 continuous active states (each separated by 10ms)
         maxcount = 15 # Look for 150ms maximum
         lowcount = 0 # Count the number of active states seen
-        while ((maxcount > 0)) and (lowcount <= 4):
+        while ((maxcount > 0) and (lowcount <= 4)):
             time.sleep(0.01) # 10ms delay between each cycle
             maxcount = maxcount - 1 # Decrement remaining cycles
             if (not GPIO.input(self.input_pin)):
                 lowcount = lowcount + 1 # One more low cycle detected
             else:
                 lowcount = 0 # Not continuously low, reset
-        if ((lowcount > 4) and (self._on_down):
+        if ((lowcount > 4) and (self._on_down)):
             self.event_queue.put((self._on_down, self))
 
     def run_inner(self):

--- a/software/authbox/gpio_button.py
+++ b/software/authbox/gpio_button.py
@@ -52,6 +52,7 @@ class Button(BasePinThread):
         self.blink_count = 0
         self.steady_state = False
         if self._on_down:
+            GPIO.setup(self.input_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
             GPIO.add_event_detect(
                 self.input_pin, GPIO.FALLING, callback=self._callback, bouncetime=150
             )

--- a/software/authbox/gpio_button.py
+++ b/software/authbox/gpio_button.py
@@ -60,19 +60,21 @@ class Button(BasePinThread):
 
     def _callback(self, unused_channel):
         """Wrapper to queue events instead of calling them directly."""
-        # This is a de-bounce filter to prevent spurious signals from triggering the logic
-        # Looks for 5 continuous active states (each separated by 10ms)
-        maxcount = 15 # Look for 150ms maximum
-        lowcount = 0 # Count the number of active states seen
-        while ((maxcount > 0) and (lowcount <= 4)):
-            time.sleep(0.01) # 10ms delay between each cycle
-            maxcount = maxcount - 1 # Decrement remaining cycles
-            if (not GPIO.input(self.input_pin)):
-                lowcount = lowcount + 1 # One more low cycle detected
-            else:
-                lowcount = 0 # Not continuously low, reset
-        if ((lowcount > 4) and (self._on_down)):
-            self.event_queue.put((self._on_down, self))
+        # If we have a callback registered, debounce the switch press
+        if (self._on_down):
+            # This is a de-bounce filter to prevent spurious signals from triggering the logic
+            # Looks for 5 continuous active states (each separated by 10ms)
+            maxcount = 15 # Look for 150ms maximum
+            lowcount = 0 # Count the number of active states seen
+            while ((maxcount > 0) and (lowcount <= 4)):
+                time.sleep(0.01) # 10ms delay between each cycle
+                maxcount = maxcount - 1 # Decrement remaining cycles
+                if (not GPIO.input(self.input_pin)):
+                    lowcount = lowcount + 1 # One more low cycle detected
+                else:
+                   lowcount = 0 # Not continuously low, reset
+            if (lowcount > 4):
+                self.event_queue.put((self._on_down, self))
 
     def run_inner(self):
         """Perform one on/off/blink pulse."""

--- a/software/authbox/gpio_button.py
+++ b/software/authbox/gpio_button.py
@@ -17,6 +17,7 @@
 
 from authbox.api import GPIO, BasePinThread
 from authbox.compat import queue
+import time
 
 
 class Button(BasePinThread):
@@ -59,7 +60,18 @@ class Button(BasePinThread):
 
     def _callback(self, unused_channel):
         """Wrapper to queue events instead of calling them directly."""
-        if self._on_down:
+        # This is a de-bounce filter to prevent spurious signals from triggering the logic
+        # Looks for 5 continuous active states (each separated by 10ms)
+        maxcount = 15 # Look for 150ms maximum
+        lowcount = 0 # Count the number of active states seen
+        while ((maxcount > 0)) and (lowcount <= 4):
+            time.sleep(0.01) # 10ms delay between each cycle
+            maxcount = maxcount - 1 # Decrement remaining cycles
+            if (not GPIO.input(self.input_pin)):
+                lowcount = lowcount + 1 # One more low cycle detected
+            else:
+                lowcount = 0 # Not continuously low, reset
+        if ((lowcount > 4) and (self._on_down):
             self.event_queue.put((self._on_down, self))
 
     def run_inner(self):

--- a/software/two_button.py
+++ b/software/two_button.py
@@ -112,14 +112,16 @@ class Dispatcher(BaseDispatcher):
 
   def abort(self, source):
     print("Abort", source)
+    self.enable_output.off()
     if self.authorized:
       command = self._get_command_line('auth', 'deauth_command', [self.badge_id])
       subprocess.call(command)
+    self.off_button.blink(1)
+    self.buzzer.beep()
     self.authorized = False
     self.warning_timer.cancel()
     self.expecting_press_timer.cancel()
     self.on_button.off()
-    self.enable_output.off()
     self.buzzer.off()
     if self.noise:
       self.noise.kill()


### PR DESCRIPTION
Hi,

We have installed authboxes on a variety of high-powered machine tools. The authboxes are mounted in close proximity to high-current switching devices and wires carrying power to motors. During operation, these tools generate a significant amount of electromagnetic interference.

These spurious emissions caused reliability issues with the original code: due to the lack of any sort of filtering on the button input GPIO (electrically or in software), we have observed the authbox incorrectly register a button press, presumably because the electromagnetic interferences were strong enough to overcome the weak internal pull-up of the Raspberry Pi for a very brief moment.

The RPi.GPIO Python library does have a "bouncetime" parameter, but it does not actually debounce anything - it just ignores further signal changes for the specified amount of time. As a result, any signal transition (even extremely brief ones due to transient spikes) will generate an event. This is undesirable and creates a strong sensitivity to ambient electromagnetic interferences.

In addition, the "two_button" example did not have any sort of audio/visual feedback when the abort button was pressed, making identifying this issue difficult.

This pull request adds:
- In gpio_button.py: Explicit configuration of the GPIO inputs to make sure that pull-ups are enabled
- In gpio_button.py: Real filtering (de-bouncing) of the button input GPIO, to eliminate spurious signals without affecting regular button presses, by ensuring that the signal stays active continuously for a minimum period of time (~50ms)
- In two_button.py: Add a beep and button blink when the abord button is pressed during operation

These modifications have been tested and proven to eliminate the spurious keypress issues. 
This pull request will make the solution significantly more robust for other users.