### PR TITLE
Cancel `expire_timer` on abort

### DIFF
--- a/software/two_button.py
+++ b/software/two_button.py
@@ -121,6 +121,7 @@ class Dispatcher(BaseDispatcher):
     self.authorized = False
     self.warning_timer.cancel()
     self.expecting_press_timer.cancel()
+    self.expire_timer.cancel()
     self.on_button.off()
     self.buzzer.off()
     if self.noise:


### PR DESCRIPTION
When a user triggers `abort` using the `off_button`, `expire_timer` remains running. In these cases, the authbox will beep after the expiration time even though the authbox is no longer authorized.

This change fixes this bug by canceling `expire_timer` in `abort`.