### PR TITLE
Avoid authorizing incorrectly on HTTP 302 redirect

### DIFF
--- a/software/two_button.ini
+++ b/software/two_button.ini
@@ -68,9 +68,9 @@ deauth_command = bash sample_deauth.sh {} {tool}
 # existing system is using.
 #
 # base_args=api_key={api_key}&tool={tool}&location={location}
-# command = curl -f {base_url}/api/v1/check?{base_args}&badge_id={}&state=initial&auth_minutes={duration}
-# extend_command = curl -f {base_url}/api/v1/check?{base_args}&badge_id={}&state=extend&auth_minutes={extend}
-# deauth_command = curl -f {base_url}/api/v1/check?{base_args}&state=cancel
+# command = curl -f -L {base_url}/api/v1/check?{base_args}&badge_id={}&state=initial&auth_minutes={duration}
+# extend_command = curl -f -L {base_url}/api/v1/check?{base_args}&badge_id={}&state=extend&auth_minutes={extend}
+# deauth_command = curl -f -L {base_url}/api/v1/check?{base_args}&state=cancel
 
 [sounds]
 # This section is for sounds played by a command e.g. over the headphone jack


### PR DESCRIPTION
The sample & common way of verifying a specific user is authenticated is to use curl to check if a certain http query completes correctly.

The -f or --fail flag passed to curl ensures zero vs non zero exit code based on http code.

Unfortunately there is a corner case where a http redirect (302 status code) is by default not followed by curl AND it returns a zero exit code, accidentally considering any badge swipe valid.

This is especially problematic as many cloud services, including AppEngine have set up an automatic redirect from http to https, making it so that a typo of http instead of https might accidentally make any badge swipe authenticate.

This change adds the -L flag to the sample .ini which will instruct curl to follow redirects instead of returning on http status code 302.